### PR TITLE
fix: Reset powerbi component when component unmounts

### DIFF
--- a/src/lib/Embed.jsx
+++ b/src/lib/Embed.jsx
@@ -30,6 +30,12 @@ class Embed extends PureComponent {
     this.updateState(this.props.config);
   }
 
+  componentWillUnmount() {
+    if (this.reportRef.current !== null) {
+      powerbi.reset(this.reportRef.current);
+    }
+  }
+
   static getDerivedStateFromProps(props, state) {
     return { ...props.config };
   }


### PR DESCRIPTION
Invoke reset when component unmount. Testing this to see if it helps with memory leak issues on Edge and IE11