### PR TITLE
Support additional report events

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,33 @@ Render
   }
 ```
 
+Button Clicked
+
+```
+  onButtonClicked={(data) => {
+    console.log(`Button ${data.title} of type ${data.type} Clicked!`);
+    }
+  }
+```
+
+Filters Applied (In documentation, but not yet supported)
+
+```
+  onFiltersApplied={(report) => {
+    console.log('Filters Applied!');
+    }
+  }
+```
+
+Command Triggered
+
+```
+  onCommandTriggered={(report) => {
+    console.log('Command Triggered!');
+    }
+  }
+```
+
 Data Element Clicked
 
 ```

--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ Button Clicked
 Filters Applied (In documentation, but not yet supported)
 
 ```
-  onFiltersApplied={(report) => {
+  onFiltersApplied={(filters) => {
     console.log('Filters Applied!');
     }
   }
@@ -247,8 +247,8 @@ Filters Applied (In documentation, but not yet supported)
 Command Triggered
 
 ```
-  onCommandTriggered={(report) => {
-    console.log('Command Triggered!');
+  onCommandTriggered={(extensionCommand) => {
+    console.log('Extension Command Triggered!');
     }
   }
 ```

--- a/src/lib/index.jsx
+++ b/src/lib/index.jsx
@@ -65,6 +65,9 @@ class Report extends PureComponent {
       onSelectData,
       onPageChange,
       onTileClicked,
+      onButtonClicked,
+      onFiltersApplied,
+      onCommandTriggered,
     } = this.props;
 
     if (onLoad) onLoad(powerbi.get(reportRef));
@@ -81,6 +84,21 @@ class Report extends PureComponent {
       report.on('pageChanged', event => {
         if (onPageChange) {
           onPageChange(event.detail);
+        }
+      });
+      report.on('buttonClicked', event => {
+        if (onButtonClicked) {
+          onButtonClicked(event.detail);
+        }
+      });
+      report.on('filtersApplied', event => {
+        if (onFiltersApplied) {
+          onFiltersApplied(event.detail);
+        }
+      });
+      report.on('commandTriggered', event => {
+        if (onCommandTriggered) {
+          onCommandTriggered(event.detail);
         }
       });
     } else if (embedType === 'dashboard') {

--- a/src/lib/index.jsx
+++ b/src/lib/index.jsx
@@ -70,9 +70,10 @@ class Report extends PureComponent {
       onCommandTriggered,
     } = this.props;
 
-    if (onLoad) onLoad(powerbi.get(reportRef));
-
     if (embedType === 'report') {
+      report.on('loaded', () => {
+        if (onLoad) onLoad(report);
+      });
       report.on('rendered', () => {
         if (onRender) onRender(report);
       });
@@ -102,6 +103,8 @@ class Report extends PureComponent {
         }
       });
     } else if (embedType === 'dashboard') {
+      if (onLoad) onLoad(report, powerbi.get(reportRef));
+
       report.on('tileClicked', event => {
         if (onTileClicked) {
           onTileClicked(event.detail);


### PR DESCRIPTION
@akshay5995 I noted [an issue](https://github.com/akshay5995/powerbi-report-component/issues/85) that would be a breaking change in my implementation of this. I noticed this when I went to add support for additional events.

This PR adds those events, but also restores the original `loaded` event for `eventType === 'report'`. 

I'm unsure of the nature of the bug the `onLoad` change was intended to fix, so unsure if this would be OK.