### PR TITLE
chore: Prevent calling .reset() of undefined

### DIFF
--- a/src/lib/Embed.jsx
+++ b/src/lib/Embed.jsx
@@ -25,7 +25,7 @@ class Embed extends PureComponent {
     if (!errors) {
       return this.embed(this.state);
     } else if (this.component !== null) {
-      this.reset();
+      return this.component.hasOwnProperty('reset') ? this.component.reset() : null;
     }
     return null;
   }


### PR DESCRIPTION
This PR should handle https://github.com/akshay5995/powerbi-report-component/issues/196

Not sure if we need to take any action if the reset() is not available tho :) 